### PR TITLE
Add static site for etl-graph

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -9,3 +9,7 @@ wlach-test:
 bucket-time:
   gcs_bucket: bucket-time
   single_page_app: false
+etl-graph:
+  gcs_bucket: etl-graph
+  single_page_app: true
+  prefix: site


### PR DESCRIPTION
This adds the bucket in the etl-graph sandbox project for hosting the output of [this repository](https://github.com/acmiyaguchi/etl-graph). 