### PR TITLE
Make glean dictionary a single page app

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,4 +38,5 @@ fission-experiment-monitoring-dashboard:
   gcs_bucket: fission-experiment-monitoring-dashboard
 glean-dictionary:
   gcs_bucket: glean-dictionary-dev
+  single_page_app: true
   public: true


### PR DESCRIPTION
This turns out to be necessary to make this work properly on protosaur, but is probably desirable anyway.