### PR TITLE
Use subdomain with etl-graph

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,7 @@ etl-graph:
   gcs_bucket: etl-graph
   single_page_app: true
   prefix: site
+  subdomain: true
 pibal:
   gcs_bucket: mozanalysis
   single_page_app: false


### PR DESCRIPTION
`etl-graph` is now using routing on the page, which breaks when not working from the domain root. 