### PR TITLE
Increase ClientTimeout to 60s

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Listen          string        `default:":8080"`
 	LogLevel        string        `split_words:"true" default:"debug"`
 	ProxyTimeout    time.Duration `split_words:"true" default:"10s"`
-	ClientTimeout   time.Duration `split_words:"true" default:"2s"`
+	ClientTimeout   time.Duration `split_words:"true" default:"60s"`
 	IdleConnTimeout time.Duration `split_words:"true" default:"120s"`
 	MaxIdleConns    int           `split_words:"true" default:"10"`
 	BaseDomain      string        `split_words:"true" default:"localhost:8080"`


### PR DESCRIPTION
We believe increasing this limit may help fix https://mozilla-hub.atlassian.net/browse/DSRE-1813 in cases where the site hosted has many images to load.